### PR TITLE
Added support for sicas captcha backend

### DIFF
--- a/server.go
+++ b/server.go
@@ -44,6 +44,7 @@ type Backend struct {
 	Userdb   string
 	Couchdb  string
 	Smtp     string
+	Sicas    string
 }
 
 // Token information

--- a/sicas.go
+++ b/sicas.go
@@ -1,0 +1,44 @@
+package gouncer
+
+import (
+	"net/http"
+	"regexp"
+)
+
+const (
+	sicasPattern = "(?i)^Sicas\\s+([a-z0-9+-_=]+)$"
+)
+
+func (creds *Credentials) ParseSicasAuth(authHeader string) (bool, []string) {
+	rxp := regexp.MustCompile(sicasPattern)
+
+	// Check if Authorization header matches
+	if match := rxp.FindStringSubmatch(authHeader); match != nil {
+		// Base64Url decode matching string
+		if decoded, err := creds.DecodeBase64(match[1]); err == nil {
+			// Split decoded string at colon
+			if segs, err := creds.SplitBasicAuth(decoded); err == nil {
+				return true, segs
+			}
+		}
+	}
+
+	return false, nil
+}
+
+type SicasResponse struct {
+	Status  int
+	Reason  string
+	Success bool
+}
+
+func (creds *Credentials) sicasValidate(host string, uuid string, captcha string) (SicasResponse, error) {
+	httpRes, err := http.Get(host + "/validate/" + uuid + "?string=" + captcha)
+	var jsonDoc SicasResponse
+
+	if err == nil {
+		err = DecodeJsonRequest(httpRes.Body, &jsonDoc)
+	}
+
+	return jsonDoc, err
+}


### PR DESCRIPTION
Will **not** break existing code as captcha validation will only be invoked if _sicas_ server url is defined in (toml) configuration file. See [sicas](//github.com/npolar/sicas) repository for latest sicas version.

Could be refactored to support other captcha backends as well at some point.

```
...
[backend]
sicas = "http://localhost:20938"
...
```
